### PR TITLE
add paginated player ratings on detail page

### DIFF
--- a/fussball/database/queries_players.py
+++ b/fussball/database/queries_players.py
@@ -81,3 +81,39 @@ def get_player_matches(con: Session, player_id: UUID) -> int:
     rows = result.fetchone()
 
     return rows[0]
+
+
+def count_player_ratings(con: Session, player_id: UUID) -> int:
+    stmt = select(func.count()).select_from(PlayerRating).where(PlayerRating.player_id == player_id)
+    result = con.execute(stmt)
+    row = result.fetchone()
+    return row[0] if row else 0
+
+
+def get_player_ratings_page(con: Session, player_id: UUID, page: int, page_size: int = 10) -> list[dict]:
+    safe_page = max(page, 1)
+    offset = (safe_page - 1) * page_size
+
+    stmt = (
+        select(
+            PlayerRating.rating,
+            PlayerRating.created_at,
+            Match.id.label("match_id"),
+        )
+        .select_from(PlayerRating)
+        .join(Match, PlayerRating.match_id == Match.id, isouter=True)
+        .where(PlayerRating.player_id == player_id)
+        .order_by(PlayerRating.created_at.desc())
+        .offset(offset)
+        .limit(page_size + 1)
+    )
+
+    rows = con.execute(stmt).fetchall()
+    return [
+        {
+            "rating": row.rating,
+            "created_at": row.created_at,
+            "match_id": row.match_id,
+        }
+        for row in rows
+    ]

--- a/fussball/pages/fragment/ui_player.py
+++ b/fussball/pages/fragment/ui_player.py
@@ -1,37 +1,100 @@
+from uuid import UUID
+from typing import Callable
+
 from uiwiz import ui
 from database.dto import PlayerWithRating
 from pages.fragment.arrow import render_rating_diff
 from pages import routes
 
 
-def render_player(player: PlayerWithRating, player_match_count: int):
+def render_player_ratings_table_content(
+    player_id: UUID,
+    ratings: list[dict],
+    page: int,
+    total_pages: int,
+    on_page_change: Callable,
+    page_size: int = 10,
+):
+    visible_ratings = ratings[:page_size]
+
+    with ui.element("table").classes(
+        "table table-zebra table-auto bg-base-300 overflow-scroll w-full whitespace-nowrap pr-4 pt-2 pb-2"
+    ):
+        with ui.element("thead"):
+            with ui.element("tr"):
+                ui.element("th", "Rating")
+                ui.element("th", "Created At")
+        with ui.element("tbody"):
+            for i, rating in enumerate(visible_ratings):
+                with ui.element("tr").classes("cursor-pointer hover:bg-base-100") as row_ele:
+                    match_id = rating.get("match_id")
+                    if match_id:
+                        row_ele.attributes["onclick"] = f"window.location.href='{routes['match_detail'].format(match_id=match_id)}'"
+
+                    previous_rating = None
+                    if i + 1 < len(visible_ratings):
+                        previous_rating = visible_ratings[i + 1]["rating"]
+                    elif len(ratings) > page_size:
+                        previous_rating = ratings[page_size]["rating"]
+
+                    with ui.element("td", str(rating["rating"])):
+                        render_rating_diff(rating["rating"], previous_rating)
+
+                    if created_at := rating.get("created_at"):
+                        ui.element("td", str(created_at.strftime("%Y-%m-%d %H:%M:%S")))
+
+    with ui.element("div").classes("mt-3 flex items-center justify-between"):
+        prev_button = ui.button("Prev").classes("btn btn-sm")
+        prev_button.on_click(
+            on_page_change,
+            target="ratings-container",
+            swap="innerHTML",
+            params={"player_id": str(player_id), "page": max(page - 1, 1)},
+        )
+        if page <= 1:
+            prev_button.attributes["disabled"] = True
+
+        ui.element("span", f"Page {page} of {total_pages}").classes("text-sm")
+
+        next_button = ui.button("Next").classes("btn btn-sm")
+        next_button.on_click(
+            on_page_change,
+            target="ratings-container",
+            swap="innerHTML",
+            params={"player_id": str(player_id), "page": min(page + 1, total_pages)},
+        )
+        if page >= total_pages:
+            next_button.attributes["disabled"] = True
+
+
+def render_player_ratings_table(
+    player_id: UUID,
+    ratings: list[dict],
+    page: int,
+    total_pages: int,
+    on_page_change: Callable,
+):
+    with ui.element() as ratings_container:
+        ratings_container.attributes["id"] = "ratings-container"
+        render_player_ratings_table_content(player_id, ratings, page, total_pages, on_page_change)
+
+
+def render_player(
+    player: PlayerWithRating,
+    player_match_count: int,
+    player_id: UUID,
+    ratings: list[dict],
+    total_pages: int,
+    on_page_change: Callable,
+):
     ui.element("h2", player.name)
     ui.element("p", f"Ranking: {player.ranking}")
     ui.element("h3", f"Total Matches: {player_match_count}")
 
     with ui.element("div").classes("grid grid-cols-1 md:grid-cols-2"):
         with ui.element():
-            ui.element("h3", "Last 10 Ratings")
-            with ui.element("table").classes(
-                "table table-zebra table-auto bg-base-300 overflow-scroll w-full whitespace-nowrap pr-4 pt-2 pb-2"
-            ):
-                with ui.element("thead"):
-                    with ui.element("tr"):
-                        ui.element("th", "Rating")
-                        ui.element("th", "Created At")
-                with ui.element("tbody"):
-                    history = player.history
-                    for i, rating in enumerate(history):
-                        with ui.element("tr").classes("cursor-pointer hover:bg-base-100") as row_ele:
-                            row_ele.attributes["onclick"] = (
-                                f"window.location.href='{routes['match_detail'].format(match_id=rating.get('match_id'))}'"
-                            )
-                            previous_rating = history[i + 1]["rating"] if i + 1 < len(history) else None
-                            with ui.element("td", str(rating["rating"])):
-                                render_rating_diff(rating["rating"], previous_rating)
-
-                            if created_at := rating.get("created_at"):
-                                ui.element("td", str(created_at.strftime("%Y-%m-%d %H:%M:%S")))
+            ui.element("h3", "Ratings")
+            render_player_ratings_table(player_id, ratings, page=1, total_pages=total_pages, on_page_change=on_page_change)
 
             ratings = [entry["rating"] for entry in reversed(player.history)] if player.history else []
             min_rating = ((min(ratings) // 100) * 100 - 100) if ratings else 0

--- a/fussball/pages/player.py
+++ b/fussball/pages/player.py
@@ -1,10 +1,17 @@
 from uuid import uuid4
 import uuid
+import math
 from pydantic import BaseModel
 from uiwiz import Page, PageRouter
 from database.setup import Connection
-from database.queries_players import get_player_matches, list_players, show_player
-from pages.fragment.ui_player import render_player, render_player_list
+from database.queries_players import (
+    count_player_ratings,
+    get_player_matches,
+    get_player_ratings_page,
+    list_players,
+    show_player,
+)
+from pages.fragment.ui_player import render_player, render_player_list, render_player_ratings_table_content
 from database.tables import Player
 from datetime import datetime, timezone
 from uiwiz import ui
@@ -54,9 +61,32 @@ def new_player(con: Connection):
 
 @player_router.page("/{player_id}", page_definition_class=PageContentWidth, title="Player Details")
 def view_player(player_id: str, con: Connection, page: Page):
-    player = show_player(con, uuid.UUID(player_id))
-    player_match_count = get_player_matches(con, uuid.UUID(player_id))
-    render_player(player, player_match_count)
+    player_uuid = uuid.UUID(player_id)
+    player = show_player(con, player_uuid)
+    player_match_count = get_player_matches(con, player_uuid)
+    total_ratings = count_player_ratings(con, player_uuid)
+    total_pages = max(1, math.ceil(total_ratings / 10))
+    ratings = get_player_ratings_page(con, player_uuid, page=1, page_size=10)
+
+    render_player(player, player_match_count, player_uuid, ratings, total_pages, player_ratings_page)
+
+
+@player_router.ui("/{player_id}/ratings/{page}")
+def player_ratings_page(player_id: str, page: int, con: Connection):
+    player_uuid = uuid.UUID(player_id)
+    safe_page = max(page, 1)
+    total_ratings = count_player_ratings(con, player_uuid)
+    total_pages = max(1, math.ceil(total_ratings / 10))
+    safe_page = min(safe_page, total_pages)
+    ratings = get_player_ratings_page(con, player_uuid, page=safe_page, page_size=10)
+
+    render_player_ratings_table_content(
+        player_id=player_uuid,
+        ratings=ratings,
+        page=safe_page,
+        total_pages=total_pages,
+        on_page_change=player_ratings_page,
+    )
 
 
 @player_router.page("/")


### PR DESCRIPTION
## Summary
- add server-side pagination queries for player rating history with total-count calculation and page/offset support
- add HTMX partial-swap endpoint and UI controls (Prev/Next + Page X of N) for player detail ratings table
- keep the player trend chart behavior unchanged (still based on the recent history snapshot)

## Notes
- pagination page size is set to 10 ratings per page
- tests were not run in this environment because pytest is not installed